### PR TITLE
fix: promote scheduled retries and align docs with reality

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22.4'
+          go-version: '1.23.0'
           cache: false
 
       - name: Build binaries

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Go build artifacts
 bin/
 dist/
+.cache/
 *.out
 
 # Test binary, built with `go test -c`

--- a/README.md
+++ b/README.md
@@ -1,108 +1,69 @@
-# 🔨 TaskForge
+# TaskForge
 
 [![CI](https://img.shields.io/github/actions/workflow/status/2bxtech/taskforge/ci.yml?branch=main&label=build)](https://github.com/2bxtech/taskforge/actions/workflows/ci.yml)
 [![Integration](https://img.shields.io/github/actions/workflow/status/2bxtech/taskforge/integration.yml?branch=main&label=integration)](https://github.com/2bxtech/taskforge/actions/workflows/integration.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/2bxtech/taskforge)](https://goreportcard.com/report/github.com/2bxtech/taskforge)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A distributed task queue system built with Go, demonstrating distributed systems patterns and fault-tolerant design.
+TaskForge is a bounded Go prototype for exploring task-queue and worker fault-tolerance patterns. It is a library and demonstration project, not a production-ready queue service.
 
-## ✨ What TaskForge Shows
+## Implemented
 
-**Distributed Systems Implementation**
-- Redis Streams with consumer groups for message delivery
-- Worker engine with Observer, Command, and Bulkhead patterns
-- Circuit breakers and rate limiting for fault tolerance
-- Exponential backoff retry with jitter and dead letter queues
+- Redis Streams queue backend with consumer groups
+- Enqueue, dequeue, acknowledgement, retry scheduling, and dead-letter handling
+- Worker engine using command and observer patterns
+- Bulkhead-style admission control, circuit breakers, and rate limiters
+- Redis and worker-engine demonstrations
+- Unit tests plus a Redis-backed delivery-path integration test
 
-**Go Code Practices**
-- SOLID principles with dependency injection
-- Interface-driven design for pluggable components
-- Error handling and structured logging
-- Concurrent processing with resource management
+## Explicitly out of scope
 
-**Design Patterns**
-- Factory and Strategy patterns for extensibility  
-- Observer pattern for event monitoring
-- Bulkhead isolation to prevent cascade failures
-- Priority queues with FIFO ordering within levels
+- The programs under `cmd/` are labeled scaffolding; they are not deployable API, CLI, worker, or scheduler services.
+- Scheduled retries are promoted opportunistically by workers polling a queue. There is no independent scheduler service.
+- Resource limits are logical admission-control budgets. They do not enforce operating-system CPU or memory limits.
+- Queue statistics and observability are prototype-level, not production telemetry.
+- PostgreSQL, NATS, authentication, and the broader configuration surface are design placeholders.
 
-## 🚀 Quick Demo
+See [docs/status-and-scope.md](docs/status-and-scope.md) for the component inventory and delivery semantics.
 
-```bash
-# Clone and setup
-git clone https://github.com/2bxtech/taskforge.git
-cd taskforge
-go mod tidy
+## Run the demonstrations
 
-# Start Redis (requires Docker)
-docker run -d -p 6379:6379 redis:7-alpine
-
-# Try the demos
-make redis-demo          # Redis queue backend demo
-make worker-demo         # Complete worker engine demo
-make demo-all           # Run both demos
-```
-
-## �️ Architecture Overview
-
-### Core Components
-- **Queue Backend**: Redis Streams implementation with consumer groups
-- **Worker Engine**: Task processing with resource management  
-- **Task System**: 6 task types (webhook, email, image, data, scheduled, batch)
-- **Observability**: Event monitoring with health tracking
-
-### Features
-- Consumer groups, retries, dead letter queues
-- Batch operations, connection pooling, priority scheduling
-- Circuit breakers, bulkhead isolation, graceful degradation
-- Health checks, metrics collection, event tracking
-
-## 📊 Project Status
-
-**Phase 1 Complete**: Core architecture and type system  
-**Phase 2A Complete**: Redis Queue Backend with consumer groups  
-**Phase 2B Complete**: Worker Engine with fault tolerance patterns
-
-**Built and tested** - Functional distributed task queue system.
-
-## 🔧 Development
+Requirements: Go 1.23+, Docker, and `make`.
 
 ```bash
-# Build all components
-make build
-
-# Run tests
-make test
-
-# Run integration tests (requires Redis)
-make test-integration
-
-# Try the demos
-make redis-demo        # Redis queue backend demo  
-make worker-demo       # Worker engine with fault tolerance
-make demo-all         # Run both demos sequentially
+docker run -d --name taskforge-redis -p 6379:6379 redis:7-alpine
+make redis-demo
+make worker-demo
 ```
 
-## 📁 Project Structure
+The worker demo runs until interrupted.
 
+## Test
+
+```bash
+go test ./...
+
+# Requires Redis on localhost:6379
+go test -tags=integration ./tests/integration
 ```
-├── pkg/types/              # Public interfaces and types
-├── internal/queue/         # Redis queue implementation
-├── internal/worker/        # Worker engine with fault tolerance
-├── cmd/                    # Application entry points
-├── examples/              # Working demonstrations
-└── tests/integration/     # Integration test suite
+
+The integration test covers enqueue → worker execution → scheduled retry → second execution → dead-letter state.
+
+## Project layout
+
+```text
+pkg/types/              Public interfaces and task/configuration types
+internal/queue/redis/   Redis Streams queue implementation
+internal/worker/        Worker engine and fault-tolerance patterns
+examples/               Runnable demonstrations
+tests/integration/      Redis-backed delivery-path test and demo smoke scripts
+cmd/                    Non-functional application scaffolding
+docs/                   Scope and assessment records
 ```
 
-## 🎯 Technical Implementation
+## Build
 
-- **Go 1.22** with concurrency patterns
-- **Redis Streams** for distributed queuing  
-- **Interface-driven design** with pluggable backends
-- **Testing** with race detection and coverage
-- **Working demos** showing functionality
+```bash
+go build ./...
+```
 
----
-
-*A distributed task queue system built with Go and Redis.*
+This compilation check includes the scaffolding under `cmd/`; a successful build does not imply that those programs provide services.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("TaskForge API server - Phase 2B implementation")
+	fmt.Println("TaskForge API scaffold: service not implemented; run examples instead")
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("TaskForge CLI - Phase 2B implementation")
+	fmt.Println("TaskForge CLI scaffold: commands not implemented; run examples instead")
 }

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 func main() {
-	// TODO: Implement scheduler service
+	fmt.Println("TaskForge scheduler scaffold: standalone scheduling is not implemented")
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -3,5 +3,5 @@ package main
 import "fmt"
 
 func main() {
-	fmt.Println("TaskForge Worker - Phase 2B implementation")
+	fmt.Println("TaskForge worker-service scaffold: run examples/worker-engine-demo instead")
 }

--- a/docs/status-and-scope.md
+++ b/docs/status-and-scope.md
@@ -1,0 +1,46 @@
+# TaskForge status and scope
+
+## Purpose
+
+TaskForge is a learning prototype for Go queue and worker primitives. Its supported artifact is the library code under `internal/queue` and `internal/worker`, exercised through `examples/` and tests. It is not presented as an operational distributed task-queue product.
+
+## Component status
+
+| Component | Status | Evidence and limits |
+|---|---|---|
+| Redis queue backend | Implemented prototype | Redis Streams, consumer groups, task hashes, acknowledgement, retry scheduling, and DLQ operations |
+| Worker engine | Implemented prototype | Polling, command dispatch, observer events, graceful-stop machinery, and failure handling |
+| Retry delivery | Implemented prototype | Failed deliveries are acknowledged, persisted, scheduled in a sorted set, and promoted when a worker polls the target queue |
+| Dead-letter handling | Implemented prototype | Exhausted tasks are acknowledged and copied to a queue-specific DLQ stream |
+| Bulkhead/circuit breaker/rate limiter | Implemented patterns | In-process controls only; resource quantities are admission budgets rather than OS enforcement |
+| Examples | Runnable | Require a reachable Redis instance |
+| API, CLI, worker service, scheduler service | Scaffolding | `cmd/` programs intentionally do not claim operational behavior |
+| PostgreSQL/NATS backends and production telemetry | Not implemented | Types/configuration may reserve future design space |
+
+## Delivery semantics
+
+1. `Enqueue` writes the serialized task to a task hash and appends a Redis Stream entry.
+2. `Dequeue` first promotes due retries for the requested queue, then reads through a consumer group.
+3. A successful worker execution calls `Ack`, acknowledges the Stream delivery, and marks the task completed.
+4. A failed execution with attempts remaining persists the incremented retry state, acknowledges the current delivery, and adds the task ID to the scheduled sorted set.
+5. A later queue poll atomically removes a due scheduled entry and appends its replacement delivery using a Redis script.
+6. A failure with no attempts remaining acknowledges the delivery and moves the task to the queue-specific DLQ stream.
+
+The retry promotion step is deliberately worker-driven. If no worker polls a queue, retries for that queue remain scheduled.
+The scheduled-set key is configurable so independent TaskForge instances can isolate their retry state.
+
+## Resource-budget semantics
+
+`BulkheadConfig.MaxTotalMemoryMB` is an explicit logical budget with a 512 MB default. It is not derived from `runtime.MemStats.Sys`: that metric reports memory obtained by the Go runtime, not total or available host memory. Operators embedding the library should configure the budget for their workload.
+
+## Verification
+
+Run:
+
+```bash
+go test ./...
+go test -race ./...
+go test -tags=integration ./tests/integration
+```
+
+The integration suite expects Redis at `localhost:6379` and verifies the delivery lifecycle through a real worker processor.

--- a/internal/queue/README.md
+++ b/internal/queue/README.md
@@ -1,6 +1,6 @@
 # TaskForge Redis Queue Backend
 
-This document covers the Redis Queue Backend implementation in TaskForge.
+This document covers the Redis Queue Backend implementation in TaskForge. See [docs/status-and-scope.md](../../docs/status-and-scope.md) for what is implemented versus scaffolding across the whole repository.
 
 ## Architecture Overview
 
@@ -28,7 +28,7 @@ internal/queue/
 └── README.md            # This documentation
 
 examples/
-└── redis_demo.go        # Complete usage demonstration
+└── redis-demo/main.go   # Complete usage demonstration
 ```
 
 ## Core Components
@@ -226,10 +226,8 @@ taskforge:stream:{queue_name}:dlq      # Dead letter queue
 
 ### Integration Tests
 
-- Real Redis connection testing
-- End-to-end message flow
-- Consumer group behavior
-- Failure recovery scenarios
+- `redis_test.go`'s `TestConnectionManager_Integration` checks connectivity/health-check against a real Redis instance (skips if unreachable).
+- `tests/integration/delivery_path_test.go` (`go test -tags=integration ./tests/integration`) drives a real worker through enqueue → execution → scheduled retry → second execution → dead-letter, against a real Redis instance.
 
 ### Mock Implementation
 
@@ -386,37 +384,23 @@ config := &redis.Config{
 
 ## Performance Characteristics
 
-### Throughput
-
-- **Single Task Operations**: ~10,000 ops/second
-- **Batch Operations**: ~50,000 tasks/second in batches of 100
-- **Dequeue Operations**: ~5,000 ops/second with 1s timeout
-
-### Memory Usage
-
-- **Per Task Overhead**: ~1KB (serialized JSON + Redis metadata)
-- **Connection Pool**: Configurable, default 10 connections
-- **Stream Trimming**: Automatic with configurable limits
+No throughput or memory numbers are published here. `redis_test.go` has component-level benchmarks (`go test -bench=. -benchmem ./internal/queue/redis`) covering serialization, but there is no benchmarked end-to-end throughput figure for enqueue/dequeue against a real Redis instance, so none is claimed. Measure against your own deployment if you need one.
 
 ### Scalability
 
-- **Horizontal Scaling**: Multiple workers across machines
-- **Queue Isolation**: Independent queues for different workloads
-- **Priority Lanes**: Critical tasks bypass normal queues
+- **Horizontal Scaling**: Multiple worker processes can consume from the same consumer group
+- **Queue Isolation**: Independent streams per queue name
+- **Priority Lanes**: Sorted-set score ordering biases dequeue toward higher priority, FIFO within a priority level
 
 ## Security Considerations
 
 ### Authentication
 
-- Redis AUTH support via password configuration
-- TLS connection support (configurable)
-- Network-level security (VPC, firewall rules)
+- Redis AUTH support via `Config.Password`
 
-### Data Security
+### Not implemented
 
-- Task payload encryption (application-level)
-- Secure credential handling
-- Audit logging for sensitive operations
+The following are common queue-backend security features that this repository does **not** implement: TLS to Redis, application-level payload encryption, and audit logging. `pkg/types/config.go` reserves an `EncryptionConfig` struct as a placeholder for future design; nothing currently reads it. Network-level security (VPC, firewall rules, `redis-server --tls-*`) is the operator's responsibility and is outside this codebase.
 
 ## Troubleshooting
 
@@ -493,8 +477,4 @@ config := &redis.Config{
 - [Redis Streams Documentation](https://redis.io/topics/streams-intro)
 - [Go Redis Client](https://github.com/redis/go-redis)
 - [SOLID Principles in Go](https://dave.cheney.net/2016/08/20/solid-go-design)
-- [TaskForge Technical Documentation](../taskforge%20context%20tech%20doc.txt)
-
----
-
-This Redis Queue Backend implementation uses standard Go development patterns with comprehensive error handling and distributed systems features.
+- [docs/status-and-scope.md](../../docs/status-and-scope.md)

--- a/internal/queue/redis/config.go
+++ b/internal/queue/redis/config.go
@@ -32,6 +32,7 @@ type Config struct {
 
 	// Priority queue settings
 	PrioritySetPrefix string `json:"priority_set_prefix" yaml:"priority_set_prefix"` // Prefix for priority sorted sets
+	ScheduledSetName  string `json:"scheduled_set_name" yaml:"scheduled_set_name"`   // Global retry schedule sorted set
 
 	// Dead letter queue settings
 	DLQSuffix     string `json:"dlq_suffix" yaml:"dlq_suffix"`           // Suffix for DLQ stream names
@@ -92,6 +93,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("consumer group is required")
 	}
 
+	if c.ScheduledSetName == "" {
+		return fmt.Errorf("scheduled set name is required")
+	}
+
 	if c.BlockTime < 0 {
 		return fmt.Errorf("block time cannot be negative")
 	}
@@ -127,6 +132,7 @@ func DefaultConfig() *Config {
 
 		// Priority queue settings
 		PrioritySetPrefix: "taskforge:priority:",
+		ScheduledSetName:  "taskforge:scheduled",
 
 		// Dead letter queue settings
 		DLQSuffix:     ":dlq",
@@ -191,6 +197,9 @@ func (c *Config) MergeWithDefaults() *Config {
 	}
 	if c.PrioritySetPrefix == "" {
 		c.PrioritySetPrefix = defaults.PrioritySetPrefix
+	}
+	if c.ScheduledSetName == "" {
+		c.ScheduledSetName = defaults.ScheduledSetName
 	}
 	if c.DLQSuffix == "" {
 		c.DLQSuffix = defaults.DLQSuffix

--- a/internal/queue/redis/helpers.go
+++ b/internal/queue/redis/helpers.go
@@ -216,6 +216,10 @@ func (r *Queue) scheduleRetry(ctx context.Context, task *types.Task, reason stri
 	task.NextRetryAt = &nextRetry
 	task.Status = types.TaskStatusPending
 
+	if err := r.UpdateTask(ctx, task); err != nil {
+		return fmt.Errorf("failed to persist retry state: %w", err)
+	}
+
 	// If retry time is in the future, schedule it
 	if nextRetry.After(time.Now()) {
 		return r.ScheduleRetry(ctx, task.ID, nextRetry)
@@ -445,6 +449,17 @@ func (r *Queue) MoveToDLQ(ctx context.Context, taskID string, reason string) err
 		prioritySetName := r.config.GetPrioritySetName(task.Queue)
 		pipe.ZRem(ctx, prioritySetName, taskID)
 
+		// Acknowledge the delivery that exhausted its retries so it cannot be
+		// reclaimed from the consumer group's pending-entry list.
+		streamName := r.config.GetStreamName(task.Queue)
+		entryID, findErr := r.findStreamEntryID(ctx, streamName, taskID)
+		if findErr != nil {
+			return fmt.Errorf("failed to find stream entry for DLQ: %w", findErr)
+		}
+		if entryID != "" {
+			pipe.XAck(ctx, streamName, r.config.ConsumerGroup, entryID)
+		}
+
 		// Update task status
 		taskHashKey := r.config.GetTaskHashKey(taskID)
 		pipe.HSet(ctx, taskHashKey, map[string]interface{}{
@@ -508,18 +523,35 @@ func (r *Queue) ScheduleRetry(ctx context.Context, taskID string, retryAt time.T
 	}
 
 	return r.connMgr.WithRetry(ctx, func() error {
-		// For now, we'll implement a simple approach
-		// In a larger system, you might use a separate scheduled tasks system
+		task, err := r.GetTask(ctx, taskID)
+		if err != nil {
+			return fmt.Errorf("failed to get task for retry: %w", err)
+		}
+		if task == nil {
+			return fmt.Errorf("task not found: %s", taskID)
+		}
 
-		// Update the task's retry time
 		taskHashKey := r.config.GetTaskHashKey(taskID)
+		streamName := r.config.GetStreamName(task.Queue)
+		entryID, err := r.findStreamEntryID(ctx, streamName, taskID)
+		if err != nil {
+			return fmt.Errorf("failed to find stream entry for retry: %w", err)
+		}
 
-		err := r.client.HSet(ctx, taskHashKey, map[string]interface{}{
+		pipe := r.client.TxPipeline()
+		pipe.HSet(ctx, taskHashKey, map[string]interface{}{
 			"next_retry_at": retryAt.Unix(),
 			"status":        string(types.TaskStatusPending),
-		}).Err()
-
-		if err != nil {
+		})
+		pipe.ZAdd(ctx, r.config.ScheduledSetName, rds.Z{
+			Score:  float64(retryAt.UnixMilli()),
+			Member: taskID,
+		})
+		pipe.ZRem(ctx, r.config.GetPrioritySetName(task.Queue), taskID)
+		if entryID != "" {
+			pipe.XAck(ctx, streamName, r.config.ConsumerGroup, entryID)
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
 			return fmt.Errorf("failed to schedule retry: %w", err)
 		}
 
@@ -541,13 +573,10 @@ func (r *Queue) GetScheduledTasks(ctx context.Context, before time.Time, limit i
 	err := r.connMgr.WithRetry(ctx, func() error {
 		// Use ZRANGEBYSCORE to efficiently get tasks scheduled before 'before' time
 		// In a sorted set, task IDs are members and next_retry_at timestamps are scores
-		// Use a global scheduled set that contains tasks from all queues
-		scheduledSetKey := "taskforge:scheduled"
-
 		// Get task IDs with scores (timestamps) less than the 'before' time
-		results, err := r.client.ZRangeByScoreWithScores(ctx, scheduledSetKey, &rds.ZRangeBy{
+		results, err := r.client.ZRangeByScoreWithScores(ctx, r.config.ScheduledSetName, &rds.ZRangeBy{
 			Min:    "0",
-			Max:    fmt.Sprintf("%d", before.Unix()),
+			Max:    fmt.Sprintf("%d", before.UnixMilli()),
 			Offset: 0,
 			Count:  int64(limit),
 		}).Result()
@@ -573,4 +602,97 @@ func (r *Queue) GetScheduledTasks(ctx context.Context, before time.Time, limit i
 	})
 
 	return tasks, err
+}
+
+// promoteScheduledRetries atomically removes due retries from the schedule and
+// appends their replacement delivery. Concurrent workers cannot promote the
+// same scheduled member, and Redis cannot observe a removed-but-not-enqueued
+// intermediate state.
+func (r *Queue) promoteScheduledRetries(ctx context.Context, queue string, before time.Time, limit int64) error {
+	results, err := r.client.ZRangeByScore(ctx, r.config.ScheduledSetName, &rds.ZRangeBy{
+		Min:   "0",
+		Max:   fmt.Sprintf("%d", before.UnixMilli()),
+		Count: limit,
+	}).Result()
+	if err != nil && err != rds.Nil {
+		return err
+	}
+
+	for _, taskID := range results {
+		task, err := r.GetTask(ctx, taskID)
+		if err != nil {
+			return err
+		}
+		if task == nil {
+			r.client.ZRem(ctx, r.config.ScheduledSetName, taskID)
+			continue
+		}
+		if task.Queue != queue {
+			continue
+		}
+
+		task.NextRetryAt = nil
+		promoted, err := r.promoteScheduledTask(ctx, task)
+		if err != nil {
+			return err
+		}
+		if promoted {
+			r.logger.Info("scheduled retry promoted",
+				types.Field{Key: "task_id", Value: task.ID},
+				types.Field{Key: "queue", Value: task.Queue},
+			)
+		}
+	}
+	return nil
+}
+
+func (r *Queue) promoteScheduledTask(ctx context.Context, task *types.Task) (bool, error) {
+	taskData, err := r.serializer.Serialize(task)
+	if err != nil {
+		return false, fmt.Errorf("failed to serialize scheduled retry: %w", err)
+	}
+
+	const promoteScript = `
+if redis.call("ZSCORE", KEYS[1], ARGV[1]) == false then
+	return 0
+end
+redis.call("ZREM", KEYS[1], ARGV[1])
+redis.call("XADD", KEYS[2], "MAXLEN", "~", ARGV[2], "*",
+	"task_id", ARGV[1],
+	"task_type", ARGV[3],
+	"priority", ARGV[4],
+	"tenant_id", ARGV[5],
+	"created_at", ARGV[6],
+	"payload", ARGV[7])
+redis.call("ZADD", KEYS[3], ARGV[8], ARGV[1])
+redis.call("HSET", KEYS[4],
+	"data", ARGV[7],
+	"status", ARGV[9],
+	"enqueued_at", ARGV[10])
+redis.call("PEXPIRE", KEYS[4], ARGV[11])
+return 1
+`
+
+	result, err := r.client.Eval(ctx, promoteScript, []string{
+		r.config.ScheduledSetName,
+		r.config.GetStreamName(task.Queue),
+		r.config.GetPrioritySetName(task.Queue),
+		r.config.GetTaskHashKey(task.ID),
+	},
+		task.ID,
+		r.config.MaxStreamLength,
+		string(task.Type),
+		string(task.Priority),
+		task.TenantID,
+		task.CreatedAt.Unix(),
+		taskData,
+		r.calculatePriorityScore(task.Priority, task.CreatedAt),
+		string(types.TaskStatusPending),
+		time.Now().Unix(),
+		r.config.TaskTTL.Milliseconds(),
+	).Int64()
+	if err != nil {
+		return false, fmt.Errorf("failed to promote scheduled retry: %w", err)
+	}
+	return result == 1, nil
 }

--- a/internal/queue/redis/redis.go
+++ b/internal/queue/redis/redis.go
@@ -149,6 +149,10 @@ func (r *Queue) Dequeue(ctx context.Context, queue string, timeout time.Duration
 		queue = "default"
 	}
 
+	if err := r.promoteScheduledRetries(ctx, queue, time.Now(), 100); err != nil {
+		return nil, fmt.Errorf("failed to promote scheduled retries: %w", err)
+	}
+
 	// Ensure consumer group exists
 	if err := r.ensureConsumerGroup(ctx, queue); err != nil {
 		r.logger.Warn("failed to ensure consumer group",

--- a/internal/queue/redis/redis_test.go
+++ b/internal/queue/redis/redis_test.go
@@ -131,6 +131,10 @@ func TestDefaultConfig(t *testing.T) {
 	if config.StreamPrefix != "taskforge:stream:" {
 		t.Errorf("Expected default stream prefix 'taskforge:stream:', got '%s'", config.StreamPrefix)
 	}
+
+	if config.ScheduledSetName != "taskforge:scheduled" {
+		t.Errorf("Expected default scheduled set name 'taskforge:scheduled', got '%s'", config.ScheduledSetName)
+	}
 }
 
 func TestConfig_MergeWithDefaults(t *testing.T) {
@@ -157,6 +161,10 @@ func TestConfig_MergeWithDefaults(t *testing.T) {
 
 	if merged.ConsumerGroup == "" {
 		t.Errorf("Expected consumer group to be filled from defaults")
+	}
+
+	if merged.ScheduledSetName == "" {
+		t.Errorf("Expected scheduled set name to be filled from defaults")
 	}
 }
 

--- a/internal/worker/README.md
+++ b/internal/worker/README.md
@@ -1,6 +1,6 @@
-# TaskForge Phase 2B: Worker Engine
+# TaskForge Worker Engine
 
-This directory contains the implementation of TaskForge's advanced worker engine, featuring enterprise-grade patterns for fault tolerance, resource management, and observability.
+This directory contains TaskForge's worker engine: a prototype implementation of fault-tolerance, resource-management, and observability patterns for task processing. See [docs/status-and-scope.md](../../docs/status-and-scope.md) for what is implemented versus scaffolding across the whole repository.
 
 ## Architecture Overview
 
@@ -39,17 +39,18 @@ type WorkerPool struct {
 
 **Key Features:**
 - Configurable concurrency levels
-- Automatic worker recovery
 - Graceful shutdown with task completion guarantees
-- Health monitoring with auto-restart capabilities
+- Health monitoring with unhealthy/recovered event notifications
 - Resource usage tracking
+
+Health events are observed and logged, not acted on: `Pool.onWorkerUnhealthy` records the event but does not restart the worker (see `worker_pool.go`). There is no auto-restart implementation today.
 
 ### Worker Implementation
 ```go
 type Worker struct {
     // Processes tasks using command pattern
     // Reports to observers via event bus
-    // Integrates with Phase 2A retry logic
+    // Integrates with the Redis queue backend's retry/DLQ logic
 }
 ```
 
@@ -104,7 +105,7 @@ config := types.DefaultConfig()
 config.Worker.Concurrency = 5
 config.Worker.Queues = []string{"high-priority", "normal", "low"}
 
-// Create queue backend (from Phase 2A)
+// Create queue backend (Redis implementation)
 queueBackend, err := factory.CreateQueueBackend(&config.Queue, logger)
 
 // Create worker pool
@@ -302,9 +303,9 @@ type ServiceCircuitConfig struct {
 }
 ```
 
-## Integration with Phase 2A
+## Integration with the Redis Queue Backend
 
-The worker engine seamlessly integrates with Phase 2A components:
+The worker engine drives the `types.QueueBackend` interface implemented by `internal/queue/redis`:
 
 ### Queue Backend Integration
 ```go
@@ -339,10 +340,10 @@ Run comprehensive unit tests:
 make test
 ```
 
-### Integration Tests  
-Test with real Redis backend:
+### Integration Tests
+Requires Redis on `localhost:6379`; exercises the enqueue → worker execution → retry → DLQ path described in [docs/status-and-scope.md](../../docs/status-and-scope.md):
 ```bash
-make test-integration
+go test -tags=integration ./tests/integration
 ```
 
 ### Worker Engine Demo
@@ -352,7 +353,7 @@ Run the full demo with Redis:
 docker-compose up redis -d
 
 # Run demo
-make worker-engine-demo
+make worker-demo
 ```
 
 ### Benchmarks
@@ -363,33 +364,9 @@ make benchmark
 
 ## Monitoring and Metrics
 
-### Key Metrics
-- **Task Throughput**: Tasks/second per worker
-- **Task Latency**: Processing time distribution
-- **Error Rates**: Failures per task type
-- **Resource Utilization**: Memory/CPU usage
-- **Queue Depths**: Backlog per queue
-- **Circuit Breaker States**: Service health
-- **Worker Health Scores**: Overall worker condition
+`types.MetricsCollector` (`pkg/types/interfaces.go`) defines the metrics hook points the worker engine calls into: task enqueued/started/completed/failed, queue depth, active workers, worker registration, and circuit breaker state transitions.
 
-### Prometheus Integration
-The worker engine exposes metrics compatible with Prometheus:
-```go
-// Task metrics
-taskforge_tasks_processed_total{worker_id, task_type, queue}
-taskforge_task_duration_seconds{worker_id, task_type, queue}  
-taskforge_task_failures_total{worker_id, task_type, error_type}
-
-// Resource metrics  
-taskforge_memory_usage_bytes{worker_id, pool_id}
-taskforge_cpu_usage_percent{worker_id}
-taskforge_active_tasks{worker_id, queue}
-
-// Health metrics
-taskforge_worker_health_score{worker_id}
-taskforge_circuit_breaker_state{service}
-taskforge_queue_depth{queue}
-```
+There is no built-in metrics exporter. Nothing in this repository exposes an HTTP `/metrics` endpoint or ships a Prometheus client. `examples/worker-engine-demo/main.go` implements `MetricsCollector` by logging each call; a real deployment would implement the interface against whatever metrics system it uses (e.g. wrap `github.com/prometheus/client_golang` counters/histograms per method) and serve them itself.
 
 ## Deployment
 
@@ -416,32 +393,16 @@ config := &types.WorkerConfig{
 - **Resource Isolation**: Task-type-specific resource pools
 - **Circuit Breakers**: Prevent cascade failures
 
-### Monitoring Alerts
+### Suggested Alert Thresholds
+These are not wired to any built-in alerting; they are starting points for an operator's own monitoring stack, driven off `HealthState.HealthScore` and `BulkheadStats`:
 - Worker health score < 0.5 (unhealthy)
-- Circuit breaker open for > 5 minutes
-- Queue depth > 1000 tasks  
-- Memory usage > 85%
-- CPU usage > 90%
-- Task failure rate > 10%
+- Circuit breaker open for an extended period
+- Queue depth growing without corresponding worker throughput
+- Bulkhead rejected-request count rising
 
 ## Performance Characteristics
 
-### Throughput
-- **High Priority Tasks**: 1000+ tasks/second
-- **Normal Priority**: 500+ tasks/second  
-- **Batch Operations**: 50+ tasks/second
-
-### Latency
-- **Task Pickup**: < 100ms from Redis
-- **Processing Start**: < 50ms after pickup
-- **Health Checks**: < 10ms per check
-- **Event Propagation**: < 5ms to observers
-
-### Resource Usage
-- **Base Memory**: ~50MB per worker pool
-- **Per Task**: Configurable via ResourceRequirements
-- **CPU Overhead**: ~5% for monitoring and coordination
-- **Network**: Minimal (Redis heartbeats only)
+No throughput or latency numbers are published here. `internal/worker/worker_test.go` and `internal/queue/redis/redis_test.go` contain component-level benchmarks (`go test -bench=. -benchmem ./...`), but there is no end-to-end throughput benchmark for the worker engine, so no headline number would be honest. If you need throughput/latency figures for your workload, run `make benchmark` and the integration test against your own Redis deployment and measure it there.
 
 ## Troubleshooting
 
@@ -460,18 +421,15 @@ logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 ```
 
 ### Diagnostic Commands
+There is no HTTP health/metrics server in this repository. Diagnostics go through code or `redis-cli` directly:
+```go
+// Worker pool status and per-worker info
+info := workerPool.GetInfo()   // see worker_pool.go
+```
 ```bash
-# Check worker health
-curl http://localhost:9090/health
-
-# View metrics
-curl http://localhost:9090/metrics
-
-# Check queue stats  
-redis-cli -c XLEN taskforge:queue:default
-
-# View circuit breaker states
-curl http://localhost:8080/api/v1/circuit-breakers
+# Check queue stats directly in Redis
+redis-cli -c XLEN taskforge:stream:default
+redis-cli -c ZCARD taskforge:scheduled
 ```
 
 ## Future Enhancements

--- a/internal/worker/bulkhead.go
+++ b/internal/worker/bulkhead.go
@@ -8,6 +8,8 @@ import (
 	"github.com/2bxtech/taskforge/pkg/types"
 )
 
+const defaultMaxTotalMemoryMB = 512
+
 // BulkheadManager implements the Bulkhead pattern for failure isolation
 // It manages resource pools and circuit breakers to prevent cascade failures
 type BulkheadManager struct {
@@ -75,23 +77,10 @@ type RateLimitSettings struct {
 
 // DefaultBulkheadConfig returns sensible default bulkhead configuration
 func DefaultBulkheadConfig() BulkheadConfig {
-	memStats := &runtime.MemStats{}
-	runtime.ReadMemStats(memStats)
-
-	// Safe conversion from uint64 to int with overflow protection
-	memoryMB := memStats.Sys / 1024 / 1024
-	var availableMemoryMB int
-
-	// Check for potential overflow before conversion
-	if memoryMB > uint64(^uint(0)>>1) {
-		// If memory exceeds int max, cap at a reasonable limit (16GB)
-		availableMemoryMB = 16384
-	} else {
-		availableMemoryMB = int(memoryMB)
-	}
-
 	return BulkheadConfig{
-		MaxTotalMemoryMB:   availableMemoryMB / 2, // Use half of available memory
+		// This is a logical admission-control budget, not a measurement of host
+		// memory. Callers should override it for their workload and environment.
+		MaxTotalMemoryMB:   defaultMaxTotalMemoryMB,
 		MaxTotalCPUPercent: 80,
 		MaxConcurrentTasks: runtime.NumCPU() * 4,
 

--- a/internal/worker/worker_pool.go
+++ b/internal/worker/worker_pool.go
@@ -233,19 +233,19 @@ func (wp *Pool) Stop(ctx context.Context) error {
 		wp.forceStop()
 	}
 
-	// Clean up resources
-	wp.cleanup()
-
 	wp.stateMutex.Lock()
 	wp.state = PoolStateStopped
 	wp.stateMutex.Unlock()
 
-	// Final notification
+	// Send the final notification before cleanup closes the event bus.
 	wp.eventBus.NotifyObservers(context.Background(), EventStopped, &EventData{
 		Event:     EventStopped,
 		WorkerID:  wp.id,
 		Timestamp: time.Now(),
 	})
+
+	// Clean up resources
+	wp.cleanup()
 
 	return nil
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -202,6 +202,13 @@ func TestWorkerEventBus(t *testing.T) {
 	}
 }
 
+func TestDefaultBulkheadConfigUsesExplicitMemoryBudget(t *testing.T) {
+	config := DefaultBulkheadConfig()
+	if config.MaxTotalMemoryMB != defaultMaxTotalMemoryMB {
+		t.Fatalf("MaxTotalMemoryMB = %d, want %d", config.MaxTotalMemoryMB, defaultMaxTotalMemoryMB)
+	}
+}
+
 // Test TaskCommandRegistry
 func TestTaskCommandRegistry(t *testing.T) {
 	logger := NewTestLogger()

--- a/tests/integration/delivery_path_test.go
+++ b/tests/integration/delivery_path_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	queueRedis "github.com/2bxtech/taskforge/internal/queue/redis"
+	"github.com/2bxtech/taskforge/internal/worker"
+	"github.com/2bxtech/taskforge/pkg/types"
+)
+
+type testLogger struct{}
+
+func (testLogger) Debug(string, ...types.Field)       {}
+func (testLogger) Info(string, ...types.Field)        {}
+func (testLogger) Warn(string, ...types.Field)        {}
+func (testLogger) Error(string, ...types.Field)       {}
+func (l testLogger) With(...types.Field) types.Logger { return l }
+
+type testMetrics struct{}
+
+func (testMetrics) RecordTaskEnqueued(types.TaskType, types.Priority, string)                      {}
+func (testMetrics) RecordTaskStarted(types.TaskType, types.Priority, string)                       {}
+func (testMetrics) RecordTaskCompleted(types.TaskType, types.Priority, string, time.Duration)      {}
+func (testMetrics) RecordTaskFailed(types.TaskType, types.Priority, string, time.Duration, string) {}
+func (testMetrics) UpdateQueueDepth(string, int64)                                                 {}
+func (testMetrics) UpdateActiveWorkers(string, int64)                                              {}
+func (testMetrics) RecordWorkerRegistered(string, []string)                                        {}
+func (testMetrics) RecordWorkerUnregistered(string)                                                {}
+func (testMetrics) UpdateWorkerStatus(string, types.WorkerStatus)                                  {}
+func (testMetrics) RecordCircuitBreakerOpen(string)                                                {}
+func (testMetrics) RecordCircuitBreakerClosed(string)                                              {}
+func (testMetrics) RecordCircuitBreakerHalfOpen(string)                                            {}
+
+type failingProcessor struct {
+	executions atomic.Int32
+}
+
+func (p *failingProcessor) Process(_ context.Context, task *types.Task) (*types.TaskResult, error) {
+	p.executions.Add(1)
+	return &types.TaskResult{TaskID: task.ID, Status: types.TaskStatusFailed}, fmt.Errorf("intentional integration failure")
+}
+func (*failingProcessor) GetSupportedTypes() []types.TaskType {
+	return []types.TaskType{types.TaskTypeWebhook}
+}
+func (*failingProcessor) GetCapabilities() []string { return []string{"integration-test"} }
+
+func TestEnqueueWorkerRetryAndDLQ(t *testing.T) {
+	logger := testLogger{}
+	queueConfig := queueRedis.DefaultConfig()
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	queueConfig.StreamPrefix = "taskforge:integration:" + suffix + ":stream:"
+	queueConfig.PrioritySetPrefix = "taskforge:integration:" + suffix + ":priority:"
+	queueConfig.ScheduledSetName = "taskforge:integration:" + suffix + ":scheduled"
+	queueConfig.TaskHashPrefix = "taskforge:integration:" + suffix + ":task:"
+	queueConfig.ConsumerGroup = "taskforge-integration-" + suffix
+
+	backend, err := queueRedis.NewRedisQueue(queueConfig, logger)
+	if err != nil {
+		t.Skipf("Redis is not available: %v", err)
+	}
+	defer backend.Close()
+
+	queueName := "delivery"
+	workerConfig := types.DefaultConfig().Worker
+	workerConfig.Queues = []string{queueName}
+	workerConfig.Concurrency = 1
+	workerConfig.Timeout = 100 * time.Millisecond
+	workerConfig.HeartbeatInterval = 100 * time.Millisecond
+	workerConfig.ShutdownTimeout = 2 * time.Second
+
+	pool, err := worker.NewWorkerPool("integration-pool", &workerConfig, backend, testMetrics{}, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	processor := &failingProcessor{}
+	if err := pool.RegisterTaskProcessor(types.TaskTypeWebhook, processor); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := pool.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Stop(context.Background())
+
+	task := &types.Task{
+		ID:         "delivery-" + suffix,
+		Type:       types.TaskTypeWebhook,
+		Priority:   types.PriorityNormal,
+		Status:     types.TaskStatusPending,
+		Queue:      queueName,
+		CreatedAt:  time.Now(),
+		MaxRetries: 1,
+	}
+	if err := backend.Enqueue(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		stored, err := backend.GetTask(ctx, task.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stored != nil && stored.Status == types.TaskStatusDeadLetter {
+			if got := processor.executions.Load(); got != 2 {
+				t.Fatalf("processor executions = %d, want 2", got)
+			}
+			if stored.CurrentRetries != 1 {
+				t.Fatalf("current retries = %d, want 1", stored.CurrentRetries)
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("task did not reach DLQ; processor executions = %d", processor.executions.Load())
+}


### PR DESCRIPTION
## Summary

Fixes TaskForge's retry delivery path and updates project documentation to accurately reflect the implemented scope.

Retries were previously scheduled into a Redis sorted set but never promoted back onto the queue because the standalone scheduler service is only scaffolding. Retry mutations were also not persisted, causing subsequent task reads to return stale retry state.

## Changes

- Persist retry state before scheduling another attempt.
- Atomically promote due retries back onto Redis Streams during queue polling.
- Make the Redis scheduled-set key configurable.
- Acknowledge retry and terminal deliveries so they cannot be reclaimed from the consumer group's pending list.
- Replace the `runtime.MemStats.Sys` memory calculation with an explicit 512 MB admission-control default.
- Fix worker-pool shutdown ordering so `EventStopped` is emitted before the event bus closes.
- Label API, CLI, worker-service, and scheduler binaries as scaffolding.
- Rewrite project and component documentation to distinguish implemented behavior from placeholders.
- Add scope and assessment-verification documentation.

## Testing

- `go test ./...`
- `go test -tags=integration ./tests/integration`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

The Redis-backed integration test exercises:

`enqueue -> worker execution -> scheduled retry -> second execution -> DLQ`

## Scope

This does not implement the standalone scheduler, API, CLI, or deployable worker service. TaskForge remains a bounded queue-and-worker prototype with runnable examples and tested delivery semantics.