### PR TITLE
ci: derive Go version from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23.0'
+        go-version-file: go.mod
         cache: true
 
     - name: Install dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23.0'
+          go-version-file: go.mod
           cache: false
 
       - name: Build binaries


### PR DESCRIPTION
## Summary

Updates the CI and integration workflows to derive the required Go toolchain version directly from `go.mod`.

## Why

The `go-redis` 9.19.0 update raised the project requirement to Go 1.24, but the workflows remained pinned to Go 1.23. This caused dependency download and build failures with:

```text
go.mod requires go >= 1.24 (running go 1.23.0; GOTOOLCHAIN=local)
```

## Changes

- Replace the fixed Go version in the CI workflow with `go-version-file: go.mod`.
- Apply the same change to the Redis integration workflow.
- Preserve the existing cache settings for each workflow.

This keeps CI synchronized with future Go version changes in `go.mod`.