### PR TITLE
fix(redis): replace deprecated sorted-set query

### DIFF
--- a/internal/queue/redis/helpers.go
+++ b/internal/queue/redis/helpers.go
@@ -609,10 +609,12 @@ func (r *Queue) GetScheduledTasks(ctx context.Context, before time.Time, limit i
 // same scheduled member, and Redis cannot observe a removed-but-not-enqueued
 // intermediate state.
 func (r *Queue) promoteScheduledRetries(ctx context.Context, queue string, before time.Time, limit int64) error {
-	results, err := r.client.ZRangeByScore(ctx, r.config.ScheduledSetName, &rds.ZRangeBy{
-		Min:   "0",
-		Max:   fmt.Sprintf("%d", before.UnixMilli()),
-		Count: limit,
+	results, err := r.client.ZRangeArgs(ctx, rds.ZRangeArgs{
+		Key:     r.config.ScheduledSetName,
+		Start:   "0",
+		Stop:    fmt.Sprintf("%d", before.UnixMilli()),
+		ByScore: true,
+		Count:   limit,
 	}).Result()
 	if err != nil && err != rds.Nil {
 		return err


### PR DESCRIPTION
## Summary

Replaces the deprecated `go-redis` `ZRangeByScore` call used when promoting scheduled retries.

## Why

After upgrading `github.com/redis/go-redis/v9` to 9.19.0, staticcheck reported:

```text
SA1019: ZRangeByScore is deprecated: Use ZRangeArgs with ByScore option instead
```

## Changes

- Replace `ZRangeByScore` with `ZRangeArgs`.
- Enable score-based selection with `ByScore: true`.
- Preserve the existing due-time cutoff and result limit.

## Validation

- `go test ./...`
- `go test -tags=integration ./tests/integration`
- `go vet ./...`
- Staticcheck
- `git diff --check`